### PR TITLE
Add imagePullSecrets to deployment template

### DIFF
--- a/deploy/cert-manager-webhook-he/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-he/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "cert-manager-webhook-he.fullname" . }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/cert-manager-webhook-he/values.yaml
+++ b/deploy/cert-manager-webhook-he/values.yaml
@@ -31,6 +31,7 @@ resources: {}
 #  cpu: 100m
 #  memory: 128Mi
 
+imagePullSecrets: []
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
Hello, it's me again

I am pulling the chart and the image from an internal Harbor registry that replicates the one you have on ghcr. Unfortunately it requires authentication so I've added a pull request to add imagePullSecrets to the helm chart Deployment template.

Thank you for your time and patience! :)